### PR TITLE
Update Flutter version to 3.38.7 in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.0'
+          flutter-version: '3.38.7'
           channel: 'stable'
 
       - name: Get dependencies
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.0'
+          flutter-version: '3.38.7'
           channel: 'stable'
 
       - name: Get dependencies
@@ -81,7 +81,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.0'
+          flutter-version: '3.38.7'
           channel: 'stable'
 
       - name: Get dependencies
@@ -105,7 +105,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.0'
+          flutter-version: '3.38.7'
           channel: 'stable'
 
       - name: Get dependencies


### PR DESCRIPTION
Bump the Flutter version from 3.27.0 to 3.38.7 in all jobs of the GitHub Actions build workflow to ensure builds use the latest stable Flutter release.